### PR TITLE
Add JSON:API content type

### DIFF
--- a/src/codegen/generate.ts
+++ b/src/codegen/generate.ts
@@ -24,6 +24,7 @@ export const contentTypes: Record<string, ContentType> = {
   '*/*': 'json',
   'application/json': 'json',
   'application/hal+json': 'json',
+  'application/vnd.api+json': 'json',
   'application/x-www-form-urlencoded': 'form',
   'multipart/form-data': 'multipart',
 };

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -50,7 +50,7 @@ export function runtime(defaults: RequestOpts) {
       },
     });
 
-    const jsonTypes = ["application/json", "application/hal+json"];
+    const jsonTypes = ["application/json", "application/hal+json", "application/vnd.api+json"];
     const isJson = contentType
       ? jsonTypes.some((mimeType) => contentType.includes(mimeType))
       : false;


### PR DESCRIPTION
This adds support for the [JSON:API ](https://jsonapi.org/) Content-Type, which is still just JSON, with some semantic rules set on top of it.